### PR TITLE
Check if the signalman events table exists before trying to insert SQL event

### DIFF
--- a/lib/signalman.rb
+++ b/lib/signalman.rb
@@ -91,7 +91,12 @@ module Signalman
     def skip?
       ["SCHEMA", "TRANSACTION"].include?(event.payload[:name]) ||
         event.payload[:name]&.include?("Signalman::") ||
-        !ActiveRecord::Base.connection.table_exists?(:signalman_events)
+        || !self.class.events_table?
+        
+        def self.events_table?
+            return @events_table if defined?(@events_table)
+          @events_table = ActiveRecord::Base.connection.table_exists?(:signalman_events)
+        end
     end
 
     def process

--- a/lib/signalman.rb
+++ b/lib/signalman.rb
@@ -90,7 +90,8 @@ module Signalman
   class QueryHandler < BaseHandler
     def skip?
       ["SCHEMA", "TRANSACTION"].include?(event.payload[:name]) ||
-        event.payload[:name]&.include?("Signalman::")
+        event.payload[:name]&.include?("Signalman::") ||
+        !ActiveRecord::Base.connection.table_exists?(:signalman_events)
     end
 
     def process

--- a/lib/signalman.rb
+++ b/lib/signalman.rb
@@ -91,16 +91,15 @@ module Signalman
     def skip?
       ["SCHEMA", "TRANSACTION"].include?(event.payload[:name]) ||
         event.payload[:name]&.include?("Signalman::") ||
-        || !self.class.events_table?
-        
-        def self.events_table?
-            return @events_table if defined?(@events_table)
-          @events_table = ActiveRecord::Base.connection.table_exists?(:signalman_events)
-        end
+        !self.class.events_table?
     end
 
     def process
       create_event event.payload.except(:connection)
+    end
+
+    def self.events_table?
+      ActiveRecord::Base.connection.table_exists?(:signalman_events)
     end
   end
 


### PR DESCRIPTION
So currently on 0.1.0 or main there's an issue when you attempt to install signalman where it attempts to insert the SQL into the signalman_events table before the table is actually created.

You can reproduce this issue with a fresh app;
`bundle add signalman`
`rails signalman:install:migrations`
`rails db:create db:migrate`
-> See error

```
ActiveRecord::StatementInvalid (Could not find table 'signalman_events'):
```

I don't love having to check if the table exists every time it inserts the SQL statement so if there's a preferred different approach let me know and I can make the adjustment, or feel free to close this in lieu of that fix😊