### PR TITLE
Fixing `bundle add` instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ How to use my plugin.
 Add this line to your application's Gemfile:
 
 ```ruby
-bundle add "signalman", group: :development
+bundle add "signalman" --group "development"
 ```
 
 Add migrations


### PR DESCRIPTION
hey @excid3 👋🏻 

I noticed that `bundle add` doesn't work as described in the README:
```
❯ bundle add "signalman", group: :development

Fetching gem metadata from https://rubygems.org/..........
Could not find gem 'signalman,' in rubygems repository https://rubygems.org/ or installed locally.
```

The `group` should use a double-dash parameter.

