### PR TITLE
Add event's name validation

### DIFF
--- a/app/models/signalman/event.rb
+++ b/app/models/signalman/event.rb
@@ -1,4 +1,6 @@
 class Signalman::Event < ApplicationRecord
+  validates :name, presence: true
+
   scope :requests, -> { where(name: "process_action.action_controller") }
   scope :mails, -> { where(name: "deliver.action_mailer") }
   scope :queries, -> { where(name: "sql.active_record") }

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -12,7 +12,7 @@
 
 ActiveRecord::Schema[7.0].define(version: 2023_07_30_020301) do
   create_table "signalman_events", force: :cascade do |t|
-    t.string "name"
+    t.string "name", null: false
     t.datetime "started_at"
     t.datetime "finished_at"
     t.float "duration"

--- a/test/models/signalman/entry_test.rb
+++ b/test/models/signalman/entry_test.rb
@@ -1,7 +1,0 @@
-require "test_helper"
-
-class Signalman::EntryTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
-end

--- a/test/models/signalman/event_test.rb
+++ b/test/models/signalman/event_test.rb
@@ -1,0 +1,11 @@
+require "test_helper"
+
+class Signalman::EventTest < ActiveSupport::TestCase
+  test "is valid" do
+    assert Signalman::Event.new(name: "sql.active_record").valid?
+  end
+
+  test "is not valid" do
+    assert_not Signalman::Event.new.valid?
+  end
+end


### PR DESCRIPTION
We've been using the event's name to know what kind of event it is.

I think we should add the name presence validator,
what do you think about it?

If you want to add more validations, please let me know, and also, if the
validation is not needed/desired feel free to close the pr.
